### PR TITLE
Set baselineOnMigrate=true

### DIFF
--- a/src/main/scala/pro/civitaspo/digdag/plugin/pg_lock/pg/PgLockPgDatabaseMigrator.scala
+++ b/src/main/scala/pro/civitaspo/digdag/plugin/pg_lock/pg/PgLockPgDatabaseMigrator.scala
@@ -3,24 +3,29 @@ package pro.civitaspo.digdag.plugin.pg_lock.pg
 
 import javax.sql.DataSource
 import org.flywaydb.core.Flyway
-import pro.civitaspo.digdag.plugin.pg_lock.pg.migration.{V0_0_0__Baseline, V0_0_1_1__CreateTable_digdag_pg_locks, V0_0_1_2__CreateIndex_digdag_pg_locks_idx_expires_on, V0_0_1_3__CreateIndex_digdag_pg_locks_idx_named_lock}
+import pro.civitaspo.digdag.plugin.pg_lock.pg.migration.{V0_0_0__Baseline_do_nothing, V0_0_1_1__CreateTable_digdag_pg_locks, V0_0_1_2__CreateIndex_digdag_pg_locks_idx_expires_on, V0_0_1_3__CreateIndex_digdag_pg_locks_idx_named_lock}
 
 
 case class PgLockPgDatabaseMigrator(config: PgLockPgConfig,
                                     ds: DataSource)
 {
+    private val v0_0_0__Baseline = new V0_0_0__Baseline_do_nothing()
+    private val v0_0_1_1__CreateTable_digdag_pg_locks = new V0_0_1_1__CreateTable_digdag_pg_locks()
+    private val v0_0_1_2__CreateIndex_digdag_pg_locks_idx_expires_on = new V0_0_1_2__CreateIndex_digdag_pg_locks_idx_expires_on()
+    private val v0_0_1_3__CreateIndex_digdag_pg_locks_idx_named_lock = new V0_0_1_3__CreateIndex_digdag_pg_locks_idx_named_lock()
+
     def migrate(): Unit =
     {
         Flyway.configure()
             .baselineOnMigrate(true)
             .dataSource(ds)
             .table(config.schemaMigrationHistoryTable)
-            .baselineVersion("0.0.0")
+            .baselineVersion(v0_0_0__Baseline.getVersion)
             .javaMigrations(
-                new V0_0_0__Baseline(),
-                new V0_0_1_1__CreateTable_digdag_pg_locks(),
-                new V0_0_1_2__CreateIndex_digdag_pg_locks_idx_expires_on(),
-                new V0_0_1_3__CreateIndex_digdag_pg_locks_idx_named_lock()
+                v0_0_0__Baseline,
+                v0_0_1_1__CreateTable_digdag_pg_locks,
+                v0_0_1_2__CreateIndex_digdag_pg_locks_idx_expires_on,
+                v0_0_1_3__CreateIndex_digdag_pg_locks_idx_named_lock
                 )
             .load()
             .migrate()

--- a/src/main/scala/pro/civitaspo/digdag/plugin/pg_lock/pg/PgLockPgDatabaseMigrator.scala
+++ b/src/main/scala/pro/civitaspo/digdag/plugin/pg_lock/pg/PgLockPgDatabaseMigrator.scala
@@ -3,7 +3,7 @@ package pro.civitaspo.digdag.plugin.pg_lock.pg
 
 import javax.sql.DataSource
 import org.flywaydb.core.Flyway
-import pro.civitaspo.digdag.plugin.pg_lock.pg.migration.{V0_0_1_1__CreateTable_digdag_pg_locks, V0_0_1_2__CreateIndex_digdag_pg_locks_idx_expires_on, V0_0_1_3__CreateIndex_digdag_pg_locks_idx_named_lock}
+import pro.civitaspo.digdag.plugin.pg_lock.pg.migration.{V0_0_0__Baseline, V0_0_1_1__CreateTable_digdag_pg_locks, V0_0_1_2__CreateIndex_digdag_pg_locks_idx_expires_on, V0_0_1_3__CreateIndex_digdag_pg_locks_idx_named_lock}
 
 
 case class PgLockPgDatabaseMigrator(config: PgLockPgConfig,
@@ -12,9 +12,12 @@ case class PgLockPgDatabaseMigrator(config: PgLockPgConfig,
     def migrate(): Unit =
     {
         Flyway.configure()
+            .baselineOnMigrate(true)
             .dataSource(ds)
             .table(config.schemaMigrationHistoryTable)
+            .baselineVersion("0.0.0")
             .javaMigrations(
+                new V0_0_0__Baseline(),
                 new V0_0_1_1__CreateTable_digdag_pg_locks(),
                 new V0_0_1_2__CreateIndex_digdag_pg_locks_idx_expires_on(),
                 new V0_0_1_3__CreateIndex_digdag_pg_locks_idx_named_lock()

--- a/src/main/scala/pro/civitaspo/digdag/plugin/pg_lock/pg/migration/V0_0_0__Baseline.scala
+++ b/src/main/scala/pro/civitaspo/digdag/plugin/pg_lock/pg/migration/V0_0_0__Baseline.scala
@@ -1,0 +1,19 @@
+package pro.civitaspo.digdag.plugin.pg_lock.pg.migration
+
+
+import org.flywaydb.core.api.migration.{BaseJavaMigration, Context}
+
+import scala.util.Using
+
+
+class V0_0_0__Baseline
+    extends BaseJavaMigration
+{
+    override def migrate(context: Context): Unit =
+    {
+        Using(context.getConnection.prepareStatement("SELECT 1")) { stmt =>
+            stmt.execute()
+        }
+
+    }
+}

--- a/src/main/scala/pro/civitaspo/digdag/plugin/pg_lock/pg/migration/V0_0_0__Baseline_do_nothing.scala
+++ b/src/main/scala/pro/civitaspo/digdag/plugin/pg_lock/pg/migration/V0_0_0__Baseline_do_nothing.scala
@@ -6,7 +6,7 @@ import org.flywaydb.core.api.migration.{BaseJavaMigration, Context}
 import scala.util.Using
 
 
-class V0_0_0__Baseline
+class V0_0_0__Baseline_do_nothing
     extends BaseJavaMigration
 {
     override def migrate(context: Context): Unit =

--- a/src/main/scala/pro/civitaspo/digdag/plugin/pg_lock/pg/migration/V0_0_1_1__CreateTable_digdag_pg_locks.scala
+++ b/src/main/scala/pro/civitaspo/digdag/plugin/pg_lock/pg/migration/V0_0_1_1__CreateTable_digdag_pg_locks.scala
@@ -1,11 +1,13 @@
 package pro.civitaspo.digdag.plugin.pg_lock.pg.migration
 
+
 import org.flywaydb.core.api.migration.{BaseJavaMigration, Context}
 
 import scala.util.Using
 
 
-class V0_0_1_1__CreateTable_digdag_pg_locks extends BaseJavaMigration
+class V0_0_1_1__CreateTable_digdag_pg_locks
+    extends BaseJavaMigration
 {
     override def migrate(context: Context): Unit =
     {

--- a/src/main/scala/pro/civitaspo/digdag/plugin/pg_lock/pg/migration/V0_0_1_2__CreateIndex_digdag_pg_locks_idx_expires_on.scala
+++ b/src/main/scala/pro/civitaspo/digdag/plugin/pg_lock/pg/migration/V0_0_1_2__CreateIndex_digdag_pg_locks_idx_expires_on.scala
@@ -1,5 +1,6 @@
 package pro.civitaspo.digdag.plugin.pg_lock.pg.migration
 
+
 import org.flywaydb.core.api.migration.{BaseJavaMigration, Context}
 
 import scala.util.Using

--- a/src/main/scala/pro/civitaspo/digdag/plugin/pg_lock/pg/migration/V0_0_1_3__CreateIndex_digdag_pg_locks_idx_named_lock.scala
+++ b/src/main/scala/pro/civitaspo/digdag/plugin/pg_lock/pg/migration/V0_0_1_3__CreateIndex_digdag_pg_locks_idx_named_lock.scala
@@ -1,5 +1,6 @@
 package pro.civitaspo.digdag.plugin.pg_lock.pg.migration
 
+
 import org.flywaydb.core.api.migration.{BaseJavaMigration, Context}
 
 import scala.util.Using


### PR DESCRIPTION
* Fix `org.flywaydb.core.api.FlywayException: Found non-empty schema(s) "public" without schema history table! Use baseline() or set baselineOnMigrate to true to initialize the schema history table.` when using this operator in digdag server mode.