### PR TITLE
Ship 0.0.1.pre2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+0.0.1.pre2 (2019-10-07)
+=======================
+
+* Fix `org.flywaydb.core.api.FlywayException: Found non-empty schema(s) "public" without schema history table! Use baseline() or set baselineOnMigrate to true to initialize the schema history table.` when using this operator in digdag server mode. [#2](https://github.com/civitaspo/digdag-operator-pg_lock/pull/2)
+* Fix a namespace bug: `Unsupported namespace: session (config)` [#3](https://github.com/civitaspo/digdag-operator-pg_lock/pull/3)
+
 0.0.1.pre (2019-10-05)
 ======================
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ _export:
     repositories:
       - https://jitpack.io
     dependencies:
-      - pro.civitaspo:digdag-operator-pg_lock:0.0.1.pre
+      - pro.civitaspo:digdag-operator-pg_lock:0.0.1.pre2
 
 +lock-with:
   # Wait during 5m until getting the named lock if another task locks.

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = 'pro.civitaspo'
-version = '0.0.1.pre'
+version = '0.0.1.pre2'
 
 def digdagVersion = '0.9.39'
 def scalaSemanticVersion = "2.13.0"

--- a/example/example.dig
+++ b/example/example.dig
@@ -4,7 +4,7 @@ _export:
       - file://${repos}
       # - https://jitpack.io
     dependencies:
-      - pro.civitaspo:digdag-operator-pg_lock:0.0.1.pre
+      - pro.civitaspo:digdag-operator-pg_lock:0.0.1.pre2
 
 +lock-with:
   # This case shows "Hello A" before "Hello B".


### PR DESCRIPTION
* Fix `org.flywaydb.core.api.FlywayException: Found non-empty schema(s) "public" without schema history table! Use baseline() or set baselineOnMigrate to true to initialize the schema history table.` when using this operator in digdag server mode. [#2](https://github.com/civitaspo/digdag-operator-pg_lock/pull/2)
* Fix a namespace bug: `Unsupported namespace: session (config)` [#3](https://github.com/civitaspo/digdag-operator-pg_lock/pull/3)